### PR TITLE
WIP: fix k8s_manifest using gavinbunney/kubectl as a provider

### DIFF
--- a/modules/aws_eks/aws-eks.yaml
+++ b/modules/aws_eks/aws-eks.yaml
@@ -127,6 +127,10 @@ output_providers:
       host: "${{{module_source}.k8s_endpoint}}"
       token: "${{data.aws_eks_cluster_auth.k8s.token}}"
       cluster_ca_certificate: "${{base64decode({module_source}.k8s_ca_data)}}"
+  kubectl:
+    host: "${{{module_source}.k8s_endpoint}}"
+    token: "${{data.aws_eks_cluster_auth.k8s.token}}"
+    cluster_ca_certificate: "${{base64decode({module_source}.k8s_ca_data)}}"
 output_data:
   aws_eks_cluster_auth:
     k8s:

--- a/modules/azure_aks/azure-aks.yaml
+++ b/modules/azure_aks/azure-aks.yaml
@@ -93,6 +93,10 @@ output_providers:
       client_certificate: "${{base64decode({module_source}.client_cert)}}"
       client_key: "${{base64decode({module_source}.client_key)}}"
       cluster_ca_certificate: "${{base64decode({module_source}.k8s_ca_data)}}"
+  kubectl:
+    host: "${{{module_source}.k8s_endpoint}}"
+    token: "${{data.aws_eks_cluster_auth.k8s.token}}"
+    cluster_ca_certificate: "${{base64decode({module_source}.k8s_ca_data)}}"
 output_data: { }
 clouds:
   - azure

--- a/modules/gcp_gke/gcp-gke.yaml
+++ b/modules/gcp_gke/gcp-gke.yaml
@@ -86,6 +86,10 @@ output_providers:
       host: "https://${{data.google_container_cluster.k8s.endpoint}}"
       token: "{k8s_access_token}"
       cluster_ca_certificate: "${{base64decode({module_source}.k8s_ca_data)}}"
+  kubectl:
+    host: "${{{module_source}.k8s_endpoint}}"
+    token: "${{data.aws_eks_cluster_auth.k8s.token}}"
+    cluster_ca_certificate: "${{base64decode({module_source}.k8s_ca_data)}}"
 output_data:
   google_container_cluster:
     k8s:

--- a/modules/k8s_manifest/k8s_manifest.py
+++ b/modules/k8s_manifest/k8s_manifest.py
@@ -17,10 +17,6 @@ class K8smanifestProcessor(ModuleProcessor):
             raise Exception(
                 f"The module {module.name} was expected to be of type k8s-manifest"
             )
-        (
-            module.data["kubeconfig"],
-            module.data["kubecontext"],
-        ) = self.get_k8s_config_context(layer)
         super(K8smanifestProcessor, self).__init__(module, layer)
 
     def process(self, module_idx: int) -> None:
@@ -29,12 +25,3 @@ class K8smanifestProcessor(ModuleProcessor):
             file_path = os.path.join(os.path.dirname(self.layer.path), file_path)
         self.module.data["file_path"] = file_path
         super(K8smanifestProcessor, self).process(module_idx)
-
-    def get_k8s_config_context(self, layer: "Layer") -> Tuple[str, str]:
-        if layer.cloud == "local":
-            return "~/.kube/config", "kind-opta-local-cluster"
-        else:
-            config_file_name = layer.get_kube_config_file_name()
-        with open(config_file_name, "r") as stream:
-            context = (yaml.safe_load(stream))["current-context"]
-        return config_file_name, context

--- a/modules/k8s_manifest/tf_module/main.tf
+++ b/modules/k8s_manifest/tf_module/main.tf
@@ -1,14 +1,13 @@
-provider "kubernetes" {
-  config_path    = var.kubeconfig
-  config_context = var.kubecontext
-
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.14.0"
+    }
+  }
 }
 
-resource "kubernetes_manifest" "manifest" {
-  manifest = yamldecode(file(var.file_path))
-  timeouts {
-    update = "5m"
-    create = "5m"
-    delete = "5m"
-  }
+
+resource "kubectl_manifest" "manifest" {
+  yaml_body = yamldecode(file(var.file_path))
 }


### PR DESCRIPTION
# Description


# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
YOUR_ANSWER
